### PR TITLE
Modified template for CopyWebpackPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,12 +88,14 @@ const plugins = () => {
       }
     }),
     new CleanWebpackPlugin(),
-    new CopyWebpackPlugin([
-      {
-        from: path.resolve(__dirname, 'src/favicon.ico'),
-        to: path.resolve(__dirname, 'dist')
-      }
-    ]),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.resolve(__dirname, 'src/favicon.ico'),
+          to: path.resolve(__dirname, 'dist')
+        }
+      ]
+    }),
     new MiniCssExtractPlugin({
       filename: filename('css')
     })


### PR DESCRIPTION
From version 3.11 you need to use a new template for the copy-webpack-plguin.