### PR TITLE
Update devtool field in webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,7 +131,7 @@ module.exports = {
     port: 4200,
     hot: isDev
   },
-  devtool: isDev ? 'source-map' : '',
+  devtool: isDev ? 'source-map' : false,
   plugins: plugins(),
   module: {
     rules: [


### PR DESCRIPTION
 Configuration.devtool should match pattern "^(inline-|hidden-|eval-)?(nosources-)?(cheap-(module-)?)?source-map$".
 BREAKING CHANGE since webpack 5: The devtool option is more strict.